### PR TITLE
Add scout URDF macro with prefix support and MoveIt config

### DIFF
--- a/scout_description/urdf/scout_mini.urdf.xacro
+++ b/scout_description/urdf/scout_mini.urdf.xacro
@@ -1,97 +1,16 @@
 <?xml version="1.0"?>
-
 <robot name="scout_mini" xmlns:xacro="http://ros.org/wiki/xacro">
 
-    <xacro:arg name="robot_namespace" default="/" />
-    <xacro:arg name="urdf_extras" default="empty.urdf" />
+  <xacro:arg name="robot_namespace" default="/" />
+  <xacro:arg name="urdf_extras" default="empty.urdf" />
 
-    <xacro:include filename="$(find scout_description)/urdf/scout_mini_wheel.xacro" />
+  <xacro:include filename="$(find scout_description)/urdf/scout_mini_macro.xacro"/>
+  <xacro:scout_mini prefix="" attach_to_world="no"/>
 
-    <!-- Variables -->
-    <xacro:property name="M_PI" value="3.14159"/>
+  <!-- Additional definitions (preserved for backwards compatibility) -->
+  <xacro:include filename="$(arg urdf_extras)" />
 
-    <!-- Vehicle Geometries -->
-    <xacro:property name="base_x_size" value="0.6200000" />
-    <xacro:property name="base_y_size" value="0.585000" />
-    <xacro:property name="base_z_size" value="0.235000" />
+  <!-- Gazebo definitions -->
+  <xacro:include filename="$(find scout_description)/urdf/scout_mini.gazebo" />
 
-    <xacro:property name="wheelbase" value="0.463951"/>
-    <xacro:property name="track" value="0.416503"/>
-    <xacro:property name="wheel_vertical_offset" value="-0.100998" />
-
-    <xacro:property name="wheel_length" value="0.8e-01" />
-    <xacro:property name="wheel_radius" value="1.600e-01" />
-
-    <!-- Base link -->
-    <link name="base_link">
-        <visual>
-            <origin
-                    xyz="0 0 0"
-                    rpy="1.5707 0 -1.5707" />
-            <geometry>
-                <mesh filename="package://scout_description/meshes/scout_mini_base_link.dae" />
-            </geometry>
-        </visual>
-        <collision>
-            <origin
-                    xyz="0 0 0"
-                    rpy="1.5707 0 -1.5707" />
-          <geometry>
-            <mesh
-              filename="package://scout_description/meshes/scout_mini_base_link.dae" />
-          </geometry>
-        </collision>
-    </link>
-
-    <link name="inertial_link">
-        <inertial>
-            <mass value="60" />
-            <origin xyz="0.0 0.0 0.0" />
-            <inertia ixx="2.288641" ixy="0" ixz="0" iyy="5.103976" iyz="0" izz="3.431465" />
-        </inertial>
-    </link>
-
-    <joint name="inertial_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <parent link="base_link" />
-        <child link="inertial_link" />
-    </joint>
-
-    <!-- Scout wheel macros -->
-    <!-- wheel labeled from 0 to 3, conter-clockwise, starting from front right wheel -->
-    <!-- motor 1 and 2 (left side) are mechanically installed in a reversed direction -->
-    <xacro:scout_mini_wheel wheel_prefix="front_right">
-        <origin xyz="${wheelbase/2} ${-track/2} ${wheel_vertical_offset}" rpy="1.57 0 0" />
-    </xacro:scout_mini_wheel>
-    <xacro:scout_mini_wheel wheel_prefix="front_left">
-        <origin xyz="${wheelbase/2} ${track/2} ${wheel_vertical_offset}" rpy="-1.57 0 0" />
-    </xacro:scout_mini_wheel>
-    <xacro:scout_mini_wheel wheel_prefix="rear_left">
-        <origin xyz="${-wheelbase/2} ${track/2} ${wheel_vertical_offset}" rpy="-1.57 0 0" />
-    </xacro:scout_mini_wheel>
-    <xacro:scout_mini_wheel wheel_prefix="rear_right">
-        <origin xyz="${-wheelbase/2} ${-track/2} ${wheel_vertical_offset}" rpy="1.57 0 0" />
-    </xacro:scout_mini_wheel>
-
-    <link name="front_mount" />
-
-    <joint name="front_mount_joint" type="fixed">
-        <origin xyz="0.175 0 0.068999" rpy="0 0 0" />
-        <parent link="base_link" />
-        <child link="front_mount" />
-    </joint>
-
-    <link name="rear_mount" />
-
-    <joint name="rear_mount_joint" type="fixed">
-        <origin xyz="-0.175 0 0.068999" rpy="0 0 0" />
-        <parent link="base_link" />
-        <child link="rear_mount" />
-    </joint>
-
-    <!-- Additional definitions -->
-    <xacro:include filename="$(arg urdf_extras)" />
-
-    <!-- Gazebo definitions  -->
-    <xacro:include filename="$(find scout_description)/urdf/scout_mini.gazebo" />
 </robot>

--- a/scout_description/urdf/scout_mini_macro.xacro
+++ b/scout_description/urdf/scout_mini_macro.xacro
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<robot name="scout_mini" xmlns:xacro="http://ros.org/wiki/xacro">
+
+<xacro:macro name="scout_mini" params="prefix:='' attach_to_world:='no'">
+
+    <xacro:include filename="$(find scout_description)/urdf/scout_mini_wheel.xacro" />
+
+    <xacro:property name="M_PI" value="3.14159"/>
+    <xacro:property name="base_x_size" value="0.6200000" />
+    <xacro:property name="base_y_size" value="0.585000" />
+    <xacro:property name="base_z_size" value="0.235000" />
+    <xacro:property name="wheelbase" value="0.463951"/>
+    <xacro:property name="track" value="0.416503"/>
+    <xacro:property name="wheel_vertical_offset" value="-0.100998" />
+    <xacro:property name="wheel_length" value="0.8e-01" />
+    <xacro:property name="wheel_radius" value="1.600e-01" />
+
+    <xacro:if value="${attach_to_world == 'yes'}">
+        <link name="world_link"/>
+        <joint name="world_frame" type="fixed">
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <parent link="world_link"/>
+            <child link="${prefix}base_link"/>
+        </joint>
+    </xacro:if>
+
+    <link name="${prefix}base_link">
+        <visual>
+            <origin xyz="0 0 0" rpy="1.5707 0 -1.5707" />
+            <geometry>
+                <mesh filename="package://scout_description/meshes/scout_mini_base_link.dae" />
+            </geometry>
+        </visual>
+        <collision>
+            <origin xyz="0 0 0" rpy="1.5707 0 -1.5707" />
+            <geometry>
+                <mesh filename="package://scout_description/meshes/scout_mini_base_link.dae" />
+            </geometry>
+        </collision>
+    </link>
+
+    <link name="inertial_link">
+        <inertial>
+            <mass value="60" />
+            <origin xyz="0.0 0.0 0.0" />
+            <inertia ixx="2.288641" ixy="0" ixz="0" iyy="5.103976" iyz="0" izz="3.431465" />
+        </inertial>
+    </link>
+
+    <joint name="inertial_joint" type="fixed">
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <parent link="${prefix}base_link" />
+        <child link="inertial_link" />
+    </joint>
+
+    <xacro:scout_mini_wheel wheel_prefix="front_right" parent_link="${prefix}base_link">
+        <origin xyz="${wheelbase/2} ${-track/2} ${wheel_vertical_offset}" rpy="1.57 0 0" />
+    </xacro:scout_mini_wheel>
+    <xacro:scout_mini_wheel wheel_prefix="front_left" parent_link="${prefix}base_link">
+        <origin xyz="${wheelbase/2} ${track/2} ${wheel_vertical_offset}" rpy="-1.57 0 0" />
+    </xacro:scout_mini_wheel>
+    <xacro:scout_mini_wheel wheel_prefix="rear_left" parent_link="${prefix}base_link">
+        <origin xyz="${-wheelbase/2} ${track/2} ${wheel_vertical_offset}" rpy="-1.57 0 0" />
+    </xacro:scout_mini_wheel>
+    <xacro:scout_mini_wheel wheel_prefix="rear_right" parent_link="${prefix}base_link">
+        <origin xyz="${-wheelbase/2} ${-track/2} ${wheel_vertical_offset}" rpy="1.57 0 0" />
+    </xacro:scout_mini_wheel>
+
+    <link name="front_mount" />
+    <joint name="front_mount_joint" type="fixed">
+        <origin xyz="0.175 0 0.068999" rpy="0 0 0" />
+        <parent link="${prefix}base_link" />
+        <child link="front_mount" />
+    </joint>
+
+    <link name="rear_mount" />
+    <joint name="rear_mount_joint" type="fixed">
+        <origin xyz="-0.175 0 0.068999" rpy="0 0 0" />
+        <parent link="${prefix}base_link" />
+        <child link="rear_mount" />
+    </joint>
+
+</xacro:macro>
+</robot>

--- a/scout_description/urdf/scout_mini_wheel.xacro
+++ b/scout_description/urdf/scout_mini_wheel.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="scout_wheel">
 
-    <xacro:macro name="scout_mini_wheel" params="wheel_prefix *joint_pose">
+    <xacro:macro name="scout_mini_wheel" params="wheel_prefix parent_link:=base_link *joint_pose">
         <link name="${wheel_prefix}_wheel_link">
             <inertial>
                 <mass value="3" />
@@ -26,7 +26,7 @@
         </link>
 
         <joint name="${wheel_prefix}_wheel" type="continuous">
-            <parent link="base_link"/>
+            <parent link="${parent_link}"/>
             <child link="${wheel_prefix}_wheel_link"/>
             <xacro:insert_block name="joint_pose"/>
             <axis xyz="0 0 -1" rpy="0 0 0" />

--- a/scout_mini_moveit_config/CMakeLists.txt
+++ b/scout_mini_moveit_config/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(scout_mini_moveit_config)
+find_package(catkin REQUIRED)
+catkin_package()
+install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/scout_mini_moveit_config/config/fake_controllers.yaml
+++ b/scout_mini_moveit_config/config/fake_controllers.yaml
@@ -1,0 +1,11 @@
+controller_list:
+  - name: fake_wheels_controller
+    type: $(arg fake_execution_type)
+    joints:
+      - front_right_wheel
+      - front_left_wheel
+      - rear_left_wheel
+      - rear_right_wheel
+initial:
+  - group: wheels
+    pose: wheels_home

--- a/scout_mini_moveit_config/config/joint_limits.yaml
+++ b/scout_mini_moveit_config/config/joint_limits.yaml
@@ -1,0 +1,24 @@
+default_velocity_scaling_factor: 0.1
+default_acceleration_scaling_factor: 0.1
+
+joint_limits:
+  front_right_wheel:
+    has_velocity_limits: true
+    max_velocity: 100
+    has_acceleration_limits: false
+    max_acceleration: 0
+  front_left_wheel:
+    has_velocity_limits: true
+    max_velocity: 100
+    has_acceleration_limits: false
+    max_acceleration: 0
+  rear_left_wheel:
+    has_velocity_limits: true
+    max_velocity: 100
+    has_acceleration_limits: false
+    max_acceleration: 0
+  rear_right_wheel:
+    has_velocity_limits: true
+    max_velocity: 100
+    has_acceleration_limits: false
+    max_acceleration: 0

--- a/scout_mini_moveit_config/config/joint_limits.yaml
+++ b/scout_mini_moveit_config/config/joint_limits.yaml
@@ -1,24 +1,37 @@
 default_velocity_scaling_factor: 0.1
 default_acceleration_scaling_factor: 0.1
 
+# Limits gotten from here: https://github.com/agilexrobotics/scout_ros/blob/01e07881cdc566c3a657e288c59a75577992d13e/scout_base/include/scout_base/scout_params.hpp#L27 :
+#         // from user manual v1.2.8 P18
+#         // max linear velocity: 1.5 m/s
+#         // max angular velocity: 0.7853 rad/s
+#         static constexpr double max_linear_speed = 1.5;     // in m/s
+#         static constexpr double max_angular_speed = 0.7853; // in rad/s
+#         static constexpr double max_speed_cmd = 10.0;       // in rad/s
+# Assuminng these are lin/ang velocities for the chassis, then:
+# max_wheel_speed = (v + w * track/2) / wheel_radius
+#                  = (1.5 + 0.7853 * 0.58306/2) / 0.160
+#                  = (1.5 + 0.2289) / 0.160
+#                  ~= 10.8 rad/s
+# (where v is linear velocity and w is angular velocity)
 joint_limits:
   front_right_wheel:
     has_velocity_limits: true
-    max_velocity: 100
+    max_velocity: 10
     has_acceleration_limits: false
     max_acceleration: 0
   front_left_wheel:
     has_velocity_limits: true
-    max_velocity: 100
+    max_velocity: 10
     has_acceleration_limits: false
     max_acceleration: 0
   rear_left_wheel:
     has_velocity_limits: true
-    max_velocity: 100
+    max_velocity: 10
     has_acceleration_limits: false
     max_acceleration: 0
   rear_right_wheel:
     has_velocity_limits: true
-    max_velocity: 100
+    max_velocity: 10
     has_acceleration_limits: false
     max_acceleration: 0

--- a/scout_mini_moveit_config/config/scout_mini.srdf.xacro
+++ b/scout_mini_moveit_config/config/scout_mini.srdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="scout_mini">
-    <xacro:arg name="prefix" default="mobile_base_" />
+    <xacro:arg name="prefix" default="" />
     <group name="wheels">
         <joint name="front_right_wheel"/>
         <joint name="front_left_wheel"/>

--- a/scout_mini_moveit_config/config/scout_mini.srdf.xacro
+++ b/scout_mini_moveit_config/config/scout_mini.srdf.xacro
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="scout_mini">
+    <xacro:arg name="prefix" default="mobile_base_" />
+    <group name="wheels">
+        <joint name="front_right_wheel"/>
+        <joint name="front_left_wheel"/>
+        <joint name="rear_left_wheel"/>
+        <joint name="rear_right_wheel"/>
+    </group>
+    <group_state name="wheels_home" group="wheels">
+        <joint name="front_right_wheel" value="0"/>
+        <joint name="front_left_wheel" value="0"/>
+        <joint name="rear_left_wheel" value="0"/>
+        <joint name="rear_right_wheel" value="0"/>
+    </group_state>
+    <disable_collisions link1="$(arg prefix)base_link" link2="front_right_wheel_link" reason="Adjacent"/>
+    <disable_collisions link1="$(arg prefix)base_link" link2="front_left_wheel_link" reason="Adjacent"/>
+    <disable_collisions link1="$(arg prefix)base_link" link2="rear_left_wheel_link" reason="Adjacent"/>
+    <disable_collisions link1="$(arg prefix)base_link" link2="rear_right_wheel_link" reason="Adjacent"/>
+    <disable_collisions link1="$(arg prefix)base_link" link2="inertial_link" reason="Adjacent"/>
+    <disable_collisions link1="$(arg prefix)base_link" link2="front_mount" reason="Adjacent"/>
+    <disable_collisions link1="$(arg prefix)base_link" link2="rear_mount" reason="Adjacent"/>
+    <disable_collisions link1="front_right_wheel_link" link2="front_left_wheel_link" reason="Never"/>
+    <disable_collisions link1="front_right_wheel_link" link2="rear_left_wheel_link" reason="Never"/>
+    <disable_collisions link1="front_right_wheel_link" link2="rear_right_wheel_link" reason="Never"/>
+    <disable_collisions link1="front_left_wheel_link" link2="rear_left_wheel_link" reason="Never"/>
+    <disable_collisions link1="front_left_wheel_link" link2="rear_right_wheel_link" reason="Never"/>
+    <disable_collisions link1="rear_left_wheel_link" link2="rear_right_wheel_link" reason="Never"/>
+    <disable_collisions link1="inertial_link" link2="front_right_wheel_link" reason="Never"/>
+    <disable_collisions link1="inertial_link" link2="front_left_wheel_link" reason="Never"/>
+    <disable_collisions link1="inertial_link" link2="rear_left_wheel_link" reason="Never"/>
+    <disable_collisions link1="inertial_link" link2="rear_right_wheel_link" reason="Never"/>
+    <disable_collisions link1="front_mount" link2="front_right_wheel_link" reason="Never"/>
+    <disable_collisions link1="front_mount" link2="front_left_wheel_link" reason="Never"/>
+    <disable_collisions link1="rear_mount" link2="rear_left_wheel_link" reason="Never"/>
+    <disable_collisions link1="rear_mount" link2="rear_right_wheel_link" reason="Never"/>
+</robot>

--- a/scout_mini_moveit_config/package.xml
+++ b/scout_mini_moveit_config/package.xml
@@ -3,7 +3,7 @@
   <name>scout_mini_moveit_config</name>
   <version>0.1.0</version>
   <description>MoveIt configuration for Scout Mini mobile base</description>
-  <maintainer email="info@2extend.robotics">Extend Robotics</maintainer>
+  <maintainer email="support@extendrobotics.com">Extend Robotics</maintainer>
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
 </package>

--- a/scout_mini_moveit_config/package.xml
+++ b/scout_mini_moveit_config/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>scout_mini_moveit_config</name>
+  <version>0.1.0</version>
+  <description>MoveIt configuration for Scout Mini mobile base</description>
+  <maintainer email="info@2extend.robotics">Extend Robotics</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+</package>


### PR DESCRIPTION
## Summary
- Refactor scout_mini URDF into macro form with `prefix` parameter support (matching the rgm2 pattern)
- Add `parent_link` param to wheel macro for prefix compatibility
- Create `scout_mini_moveit_config` package with SRDF (xacro with prefix), fake controllers, and joint limits

## Context
Part of mobile base reintegration into er_interface new architecture. The er_interface PR depends on this.